### PR TITLE
Adding ability to choose image within justin-test-jobscript

### DIFF
--- a/commands/justin-test-jobscript
+++ b/commands/justin-test-jobscript
@@ -37,7 +37,7 @@ umask 0077
 export JUSTIN_WORKDIR=`mktemp -d /tmp/justin-test-jobscript.XXXXXX`
 mkdir -p $JUSTIN_WORKDIR/home/workspace
 
-ARGS=$(getopt -o 'j:m:e:' --long 'jobscript:,mql:,monte-carlo:,env:' -- "$@") || exit
+ARGS=$(getopt -o 'j:m:e:i:' --long 'jobscript:,mql:,monte-carlo:,env:,image:' -- "$@") || exit
 eval "set -- $ARGS"
 
 while true; do
@@ -48,6 +48,8 @@ while true; do
    MQL=$2; shift 2;;
   (--monte-carlo)
    MONTECARLO="true"; shift 2;;
+  (--image)
+   IMAGE=$2; shift 2;;
   (--env)
    echo "export $2" >> $JUSTIN_WORKDIR/home/justin-jobscript-env.sh; shift 2;;
   (--) shift; break;;
@@ -73,6 +75,33 @@ echo
 
 cp "$JOBSCRIPT" $JUSTIN_WORKDIR/home/justin-jobscript.sh
 chmod +x $JUSTIN_WORKDIR/home/justin-jobscript.sh
+
+if [ "$IMAGE" != "" ] ; then
+  echo "User requested image: $IMAGE"
+  if [[ "$IMAGE" == "/"* ]]; then
+    echo "Note: User provided absolute path."
+  elif [[ "$IMAGE" == *"/"* ]]; then
+    echo "Note: User provided relative path."
+  else
+    echo "User provided image name only: will prepend /cvmfs/singularity.opensciencegrid.org/fermilab/ to image name"
+    if [[ "$IMAGE"  != *":"* ]]; then
+      echo "Will also append ':latest' to image name"
+      IMAGE="$IMAGE:latest"
+    fi
+    IMAGE="/cvmfs/singularity.opensciencegrid.org/fermilab/$IMAGE"
+  fi
+  echo "Checking the image exists"
+  stat $IMAGE > /dev/null 2>&1
+  if [ $? != 0 ]; then
+    echo "Could not find image: $IMAGE"
+    exit 5
+  fi
+  echo "Found image: $IMAGE"
+else
+  echo "Using default image /cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-sl7:latest"
+  IMAGE="/cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-sl7:latest"
+fi
+
 
 if [ "$MONTECARLO" != "" ] ; then
   replica='monte-carlo-000001-000001 000001 MONTECARLO'
@@ -136,7 +165,7 @@ echo "====Start of jobscript execution===="
   --workdir $JUSTIN_WORKDIR \
   --home $JUSTIN_WORKDIR/home:/home \
   --bind /cvmfs \
-  /cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-sl7:latest
+  $IMAGE
 echo "====End of jobscript execution===="
 
 ls -lR "$JUSTIN_WORKDIR/home/workspace"


### PR DESCRIPTION
Testing output:

<pre>
justin$ ../../dune-justin/commands/justin-test-jobscript --jobscript test_al9.jobscript --monte-carlo 1 --image fnal-wn-el9
Files created under /tmp/justin-test-jobscript.pxJfev

User requested image: fnal-wn-el9
User provided image name only: will prepend /cvmfs/singularity.opensciencegrid.org/fermilab/ to image name
Will also append ':latest' to image name
Checking the image exists
Found image: /cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-el9:latest
====Start of jobscript execution====
LSB Version:	:core-4.1-amd64:core-4.1-noarch
Distributor ID:	AlmaLinux
Description:	AlmaLinux release 9.6 (Sage Margay)
Release:	9.6
Codename:	SageMargay
did_pfn_rse: monte-carlo-000001-000001 000001 MONTECARLO
====End of jobscript execution====
/tmp/justin-test-jobscript.pxJfev/home/workspace:
total 4
-rw------- 1 calcuttj dune 26 Apr 14 14:41 justin-processed-dids.txt
justin$ ../../dune-justin/commands/justin-test-jobscript --jobscript test_al9.jobscript --monte-carlo 1 --image fnal-wn-sl7
Files created under /tmp/justin-test-jobscript.H5OjHQ

User requested image: fnal-wn-sl7
User provided image name only: will prepend /cvmfs/singularity.opensciencegrid.org/fermilab/ to image name
Will also append ':latest' to image name
Checking the image exists
Found image: /cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-sl7:latest
====Start of jobscript execution====
LSB Version:	:core-4.1-amd64:core-4.1-noarch
Distributor ID:	Scientific
Description:	Scientific Linux release 7.9 (Nitrogen)
Release:	7.9
Codename:	Nitrogen
did_pfn_rse: monte-carlo-000001-000001 000001 MONTECARLO
====End of jobscript execution====
/tmp/justin-test-jobscript.H5OjHQ/home/workspace:
total 4
-rw------- 1 calcuttj dune 26 Apr 14 14:41 justin-processed-dids.txt
justin$ ../../dune-justin/commands/justin-test-jobscript --jobscript test_al9.jobscript --monte-carlo 1 --image /cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-sl
fnal-wn-sl6:1.0/             fnal-wn-sl6:devel/           fnal-wn-sl6:latest/          fnal-wn-sl7:devel/           fnal-wn-sl7:osg3.5/          fnal-wn-sl7:xrootd/          
fnal-wn-sl6:2.0/             fnal-wn-sl6:last_from_repos/ fnal-wn-sl7:1.0/             fnal-wn-sl7:latest/          fnal-wn-sl7:osg3.6/          
justin$ ../../dune-justin/commands/justin-test-jobscript --jobscript test_al9.jobscript --monte-carlo 1 --image /cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-sl7:latest
Files created under /tmp/justin-test-jobscript.0qfO3r

User requested image: /cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-sl7:latest
Note: User provided absolute path.
Checking the image exists
Found image: /cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-sl7:latest
====Start of jobscript execution====
LSB Version:	:core-4.1-amd64:core-4.1-noarch
Distributor ID:	Scientific
Description:	Scientific Linux release 7.9 (Nitrogen)
Release:	7.9
Codename:	Nitrogen
did_pfn_rse: monte-carlo-000001-000001 000001 MONTECARLO
====End of jobscript execution====
/tmp/justin-test-jobscript.0qfO3r/home/workspace:
total 4
-rw------- 1 calcuttj dune 26 Apr 14 14:42 justin-processed-dids.txt
</pre>

If this is too verbose, feel free to remove some of the output :) 